### PR TITLE
Fix linux binary

### DIFF
--- a/vcpkg_precommit/hook.py
+++ b/vcpkg_precommit/hook.py
@@ -13,8 +13,8 @@ def get_vcpkg_binary() -> Path:
 
     binary_map = {
         ("windows", "amd64"): ("vcpkg.exe", "vcpkg-windows-x64.exe"),
-        ("linux", "x86_64"): ("vcpkg", "vcpkg-linux"),
-        ("darwin", "arm64"): ("vcpkg", "vcpkg-macos-arm64"),
+        ("linux", "x86_64"): ("vcpkg", "vcpkg-glibc"),
+        ("darwin", "arm64"): ("vcpkg", "vcpkg-macos"),
         ("darwin", "x86_64"): ("vcpkg", "vcpkg-macos"),
     }
 

--- a/vcpkg_precommit/hook.py
+++ b/vcpkg_precommit/hook.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import platform
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Optional, Sequence
 from urllib.request import urlretrieve
@@ -40,7 +41,7 @@ def get_vcpkg_binary() -> Path:
 
 def format_manifest_vcpkg_json(filename: str, vcpkg_binary: Path) -> bool:
     """Format a single vcpkg.json file."""
-    os.environ["VCPKG_ROOT"] = "/__dummy_vcpkg_root"
+    os.environ["VCPKG_ROOT"] = tempfile.TemporaryDirectory()
     result = subprocess.run(
         [str(vcpkg_binary), "format-manifest", "--x-wait-for-lock", filename],
         capture_output=True,

--- a/vcpkg_precommit/hook.py
+++ b/vcpkg_precommit/hook.py
@@ -41,7 +41,7 @@ def get_vcpkg_binary() -> Path:
 
 def format_manifest_vcpkg_json(filename: str, vcpkg_binary: Path) -> bool:
     """Format a single vcpkg.json file."""
-    os.environ["VCPKG_ROOT"] = tempfile.TemporaryDirectory()
+    os.environ["VCPKG_ROOT"] = tempfile.TemporaryDirectory().name
     result = subprocess.run(
         [str(vcpkg_binary), "format-manifest", "--x-wait-for-lock", filename],
         capture_output=True,

--- a/vcpkg_precommit/hook.py
+++ b/vcpkg_precommit/hook.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import platform
 import subprocess
 from pathlib import Path
@@ -39,6 +40,7 @@ def get_vcpkg_binary() -> Path:
 
 def format_manifest_vcpkg_json(filename: str, vcpkg_binary: Path) -> bool:
     """Format a single vcpkg.json file."""
+    os.environ["VCPKG_ROOT"] = "/__dummy_vcpkg_root"
     result = subprocess.run(
         [str(vcpkg_binary), "format-manifest", "--x-wait-for-lock", filename],
         capture_output=True,


### PR DESCRIPTION
And export a dummy `VCPKG_ROOT` as `vcpkg` bails out if this env var doesn't exist even if not required for `format-manifest`